### PR TITLE
[NSch] Allow ssh keys with public exponents which are not 35

### DIFF
--- a/NSch/NSch.Jce/SignatureRSA.cs
+++ b/NSch/NSch.Jce/SignatureRSA.cs
@@ -57,10 +57,10 @@ namespace NSch.Jce
 		}
 
 		/// <exception cref="System.Exception"></exception>
-		public virtual void SetPrvKey(byte[] d, byte[] n)
+		public virtual void SetPrvKey(byte[] d, byte[] n, byte[] e)
 		{
 			RSAPrivateKeySpec rsaPrivKeySpec = new RSAPrivateKeySpec(new BigInteger(n), new BigInteger
-				(d));
+				(d), new BigInteger (e));
 			PrivateKey prvKey = keyFactory.GeneratePrivate(rsaPrivKeySpec);
 			signature.InitSign(prvKey);
 		}

--- a/NSch/NSch/IdentityFile.cs
+++ b/NSch/NSch/IdentityFile.cs
@@ -753,7 +753,7 @@ namespace NSch
 				Type c = Sharpen.Runtime.GetType((string)JSch.GetConfig("signature.rsa"));
 				NSch.SignatureRSA rsa = (NSch.SignatureRSA)(System.Activator.CreateInstance(c));
 				rsa.Init();
-				rsa.SetPrvKey(d_array, n_array);
+				rsa.SetPrvKey(d_array, n_array, e_array);
 				rsa.Update(data);
 				byte[] sig = rsa.Sign();
 				Buffer buf = new Buffer("ssh-rsa".Length + 4 + sig.Length + 4);

--- a/NSch/NSch/Sharpen/KeyFactory.cs
+++ b/NSch/NSch/Sharpen/KeyFactory.cs
@@ -107,7 +107,7 @@ namespace Sharpen
 			RSAParameters dparams = new RSAParameters ();
 			dparams.Modulus = spec.GetModulus ().GetBytes ();
 			dparams.D = spec.GetPrivateExponent ().GetBytes ();
-			dparams.Exponent = new BigInteger (35).GetBytes ();
+			dparams.Exponent = spec.GetPublicExponent ().GetBytes ();
 			return new RSAPrivateKey (dparams);
 		}
 	}

--- a/NSch/NSch/Sharpen/RSAPrivateKeySpec.cs
+++ b/NSch/NSch/Sharpen/RSAPrivateKeySpec.cs
@@ -30,12 +30,19 @@ namespace Sharpen
 	public class RSAPrivateKeySpec: KeySpec
 	{
 		BigInteger modulus;
+		BigInteger publicExponent;
 		BigInteger privateExponent;
 
-		public RSAPrivateKeySpec (BigInteger modulus, BigInteger privateExponent)
+		public RSAPrivateKeySpec (BigInteger modulus, BigInteger privateExponent, BigInteger publicExponent)
 		{
 			this.modulus = modulus;
 			this.privateExponent = privateExponent;
+			this.publicExponent = publicExponent;
+		}
+		
+		public BigInteger GetPublicExponent ()
+		{
+			return publicExponent;
 		}
 		
 		public BigInteger GetModulus ()

--- a/NSch/NSch/SignatureRSA.cs
+++ b/NSch/NSch/SignatureRSA.cs
@@ -42,7 +42,7 @@ namespace NSch
 		void SetPubKey(byte[] e, byte[] n);
 
 		/// <exception cref="System.Exception"></exception>
-		void SetPrvKey(byte[] d, byte[] n);
+		void SetPrvKey(byte[] d, byte[] n, byte[] e);
 
 		/// <exception cref="System.Exception"></exception>
 		void Update(byte[] H);

--- a/gen/cs.patch
+++ b/gen/cs.patch
@@ -7635,6 +7635,23 @@ index 6d6b146..facf659 100644
  			//System.err.println("frst: "+frst+", scnd: "+scnd);
  			int length = sig.Length + 6 + frst + scnd;
  			tmp = new byte[length];
+diff --git a/NSch/NSch.Jce/SignatureRSA.cs b/NSch/NSch.Jce/SignatureRSA.cs
+index 0a99902..5600cb7 100644
+--- a/NSch/NSch.Jce/SignatureRSA.cs
++++ b/NSch/NSch.Jce/SignatureRSA.cs
+@@ -57,10 +57,10 @@ namespace NSch.Jce
+ 		}
+ 
+ 		/// <exception cref="System.Exception"></exception>
+-		public virtual void SetPrvKey(byte[] d, byte[] n)
++		public virtual void SetPrvKey(byte[] d, byte[] n, byte[] e)
+ 		{
+ 			RSAPrivateKeySpec rsaPrivKeySpec = new RSAPrivateKeySpec(new BigInteger(n), new BigInteger
+-				(d));
++				(d), new BigInteger (e));
+ 			PrivateKey prvKey = keyFactory.GeneratePrivate(rsaPrivKeySpec);
+ 			signature.InitSign(prvKey);
+ 		}
 diff --git a/NSch/NSch.Jcraft/HMACMD5.cs b/NSch/NSch.Jcraft/HMACMD5.cs
 index 2b80101..aed6e53 100644
 --- a/NSch/NSch.Jcraft/HMACMD5.cs
@@ -8040,7 +8057,7 @@ index a4b9e36..50ad82d 100644
  							sig.SetPubKey(f, p, q, g);
  							sig.Update(H);
 diff --git a/NSch/NSch/IdentityFile.cs b/NSch/NSch/IdentityFile.cs
-index 344fd4a..ec6897b 100644
+index 344fd4a..62636a0 100644
 --- a/NSch/NSch/IdentityFile.cs
 +++ b/NSch/NSch/IdentityFile.cs
 @@ -451,9 +451,9 @@ namespace NSch
@@ -8064,6 +8081,15 @@ index 344fd4a..ec6897b 100644
  						{
  							_buf.GetInt();
  							//_buf.getInt();
+@@ -753,7 +753,7 @@ namespace NSch
+ 				Type c = Sharpen.Runtime.GetType((string)JSch.GetConfig("signature.rsa"));
+ 				NSch.SignatureRSA rsa = (NSch.SignatureRSA)(System.Activator.CreateInstance(c));
+ 				rsa.Init();
+-				rsa.SetPrvKey(d_array, n_array);
++				rsa.SetPrvKey(d_array, n_array, e_array);
+ 				rsa.Update(data);
+ 				byte[] sig = rsa.Sign();
+ 				Buffer buf = new Buffer("ssh-rsa".Length + 4 + sig.Length + 4);
 diff --git a/NSch/NSch/JSch.cs b/NSch/NSch/JSch.cs
 index 67f29f5..6a98061 100644
 --- a/NSch/NSch/JSch.cs
@@ -8263,6 +8289,19 @@ index 0137177..b2b8af9 100644
 -		}
  	}
  }
+diff --git a/NSch/NSch/SignatureRSA.cs b/NSch/NSch/SignatureRSA.cs
+index 775955a..9863892 100644
+--- a/NSch/NSch/SignatureRSA.cs
++++ b/NSch/NSch/SignatureRSA.cs
+@@ -42,7 +42,7 @@ namespace NSch
+ 		void SetPubKey(byte[] e, byte[] n);
+ 
+ 		/// <exception cref="System.Exception"></exception>
+-		void SetPrvKey(byte[] d, byte[] n);
++		void SetPrvKey(byte[] d, byte[] n, byte[] e);
+ 
+ 		/// <exception cref="System.Exception"></exception>
+ 		void Update(byte[] H);
 diff --git a/NSch/NSch/Util.cs b/NSch/NSch/Util.cs
 index 1dd7c60..394e130 100644
 --- a/NSch/NSch/Util.cs


### PR DESCRIPTION
We had hard coded '35' as the public exponent which made things fail
for every private key which did not use 35 as the public exponent.
I do not know how this is supposed to be handled, but this is the
only way I can sanely supply the public exponent when signing data.
This fixes https://bugzilla.xamarin.com/show_bug.cgi?id=356.

If there is a better way to fix this, I'm all ears. As it is i 'fixed'
it by modifying our declarations of the java interfaces in order to
pass in the required parameter which just seems wrong.
