### PR TITLE
 Support resolving Sharpen.Unix types if merged

### DIFF
--- a/Sharpen/Sharpen/FileHelper.cs
+++ b/Sharpen/Sharpen/FileHelper.cs
@@ -15,11 +15,15 @@ namespace Sharpen
 			if (Environment.OSVersion.Platform.ToString ().StartsWith ("Win"))
 				Instance = new FileHelper ();
 			else {
-				var path = ((FilePath) typeof (FileHelper).Assembly.Location).GetParent ();
-				var assembly = Assembly.LoadFile (Path.Combine (path, "Sharpen.Unix.dll"));
-				if (assembly == null)
-					throw new Exception ("Sharpen.Unix.dll is required when running on a Unix based system");
-				Instance = (FileHelper) Activator.CreateInstance (assembly.GetType ("Sharpen.Unix.UnixFileHelper"));
+				var ufh = Type.GetType("Sharpen.Unix.UnixFileHelper");
+				if (ufh == null) {
+					var path = ((FilePath) typeof (FileHelper).Assembly.Location).GetParent();
+					var assembly = Assembly.LoadFile(Path.Combine(path, "Sharpen.Unix.dll"));
+					if (assembly == null)
+						throw new Exception("Sharpen.Unix.dll is required when running on a Unix based system");
+					ufh = assembly.GetType("Sharpen.Unix.UnixFileHelper");
+				}
+				Instance = (FileHelper)Activator.CreateInstance (ufh);
 			}
 		}
 


### PR DESCRIPTION
 Support resolving Sharpen.Unix types if merged
- Currently, FileHelper tries to dynamically load Sharper.Unix.dll in
  case of a unix system, this fails in case Sharpen.Unix is somehow
  loaded, but no from the same location of Sharpen.dll (such as assembly
  merging, or something else), this will first try to find the type
  before attempting to load an explicit assembly
