### PR TITLE
Update ScheduledThreadPoolExecutor.cs

### DIFF
--- a/Sharpen/Sharpen/ScheduledThreadPoolExecutor.cs
+++ b/Sharpen/Sharpen/ScheduledThreadPoolExecutor.cs
@@ -197,8 +197,6 @@ namespace Sharpen
 		{
 			int nextWait = ST.Timeout.Infinite;
 			while (true) {
-				if (nextWait != ST.Timeout.Infinite)
-					nextWait = Math.Max (0, nextWait);
 				newTask.WaitOne (nextWait);
 				lock (tasks) {
 					DateTime now = DateTime.Now;
@@ -209,7 +207,7 @@ namespace Sharpen
 						n--;
 					}
 					if (n < tasks.Count)
-						nextWait = (int) Math.Ceiling ((tasks[n].DueTime - DateTime.Now).TotalMilliseconds);
+						nextWait = Math.Max (0, (int) Math.Ceiling ((tasks[n].DueTime - DateTime.Now).TotalMilliseconds));
 					else
 						nextWait = ST.Timeout.Infinite;
 				}


### PR DESCRIPTION
There is a small chance that -1 could be a calculated result for the next time to wait, which would result in an inifinite wait duration (instead of 0).  Since AddTask will not Set if the new task isnt added in the first slot, this has the result of completely stalling the scheduler.